### PR TITLE
Update license

### DIFF
--- a/license
+++ b/license
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) Elan Shanker and Node.js contributors. All rights reserved.
+Copyright (c) 2016 Elan Shanker and Node.js contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
MIT license needs both of year and copyright holder.
Please complete MIT license. We want to use this without legal risk.